### PR TITLE
Fix typos, bug, docs and add tool tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Discord bot powered by Google's Generative AI, built with Python and Flask.
 - Google ADK for agents
 - A web GUI for administration
 - PostgreSQL database for storing bot configurations
-- Custom bot management system with thread-based scheduling with Redis
+- Custom bot management system with thread-based scheduling using Redis
 
 ## Prerequisites
 

--- a/discord_agents/domain/bot.py
+++ b/discord_agents/domain/bot.py
@@ -135,7 +135,7 @@ class MyBot:
         logger.info(f"Bot is ready. Logged in as {self._bot.user}")
         if self._cog:
             try:
-                await self._bot.add_cog(self._cog)
+                self._bot.add_cog(self._cog)
                 logger.info(f"Cog added successfully: {self._cog}")
 
                 agent = self._cog.my_agent

--- a/discord_agents/scheduler/tasks.py
+++ b/discord_agents/scheduler/tasks.py
@@ -35,7 +35,7 @@ def should_start_bot_in_model_task(bot_id: str) -> None:
 def should_start_bot_task(
     bot_id: str, init_data: MyBotInitConfig, setup_data: MyAgentSetupConfig
 ) -> None:
-    """Set bot to should_start state and clear config"""
+    """Set bot to should_start state and store config"""
     logger.info(f"Dispatch start bot task for {bot_id}")
     redis_broker.set_should_start(bot_id, init_data, setup_data)
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import types
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Create stub modules for external dependencies to allow importing Tools
+dum_module = types.ModuleType("google")
+adk_module = types.ModuleType("google.adk")
+tools_module = types.ModuleType("google.adk.tools")
+base_tool_module = types.ModuleType("google.adk.tools.base_tool")
+
+class BaseTool:  # minimal BaseTool stub
+    name = "stub"
+
+base_tool_module.BaseTool = BaseTool
+tools_module.base_tool = base_tool_module
+adk_module.tools = tools_module
+dum_module.adk = adk_module
+sys.modules.setdefault("google", dum_module)
+sys.modules.setdefault("google.adk", adk_module)
+sys.modules.setdefault("google.adk.tools", tools_module)
+sys.modules.setdefault("google.adk.tools.base_tool", base_tool_module)
+
+# Stub out tool_def modules with simple objects
+stub_tool = BaseTool()
+stub_tool.name = "dummy"
+for name in [
+    "search_tool",
+    "life_env_tool",
+    "rpg_dice_tool",
+    "content_extractor_tool",
+    "summarizer_tool",
+    "math_tool",
+    "note_wrapper_tool",
+]:
+    module_name = f"discord_agents.domain.tool_def.{name}"
+    module = types.ModuleType(module_name)
+    setattr(module, name, stub_tool)
+    sys.modules.setdefault(module_name, module)
+
+from discord_agents.domain.tools import Tools, TOOLS_DICT
+from discord_agents.domain.tool_def.note_wrapper_tool import note_wrapper_tool
+
+
+def test_get_existing_tool_returns_correct_instance():
+    tool = Tools.get_tool("notes")
+    assert tool is note_wrapper_tool
+
+
+def test_get_unknown_tool_raises_key_error():
+    with pytest.raises(KeyError):
+        Tools.get_tool("unknown")
+


### PR DESCRIPTION
## Summary
- fix typo in README
- avoid awaiting `add_cog` in `MyBot._on_ready`
- correct docstring in scheduler tasks
- add tests for tool loading utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684372f7a6b4832fa8bb3dfc808ace29